### PR TITLE
fix(openai-base): preserve content when response contains both content and toolCalls

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/jvmTest/kotlin/deepseek/DeepSeekLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/jvmTest/kotlin/deepseek/DeepSeekLLMClientTest.kt
@@ -251,6 +251,67 @@ class DeepSeekLLMClientTest {
         assertTrue(ex.message!!.contains("Moderation is not supported"))
     }
 
+    // Reproduces: https://github.com/JetBrains/koog/issues/1589
+    // DeepSeek (and other OpenAI-compatible providers) may return a choice with both
+    // `content` and `tool_calls`. Previously only the tool calls were returned and the
+    // content was silently dropped.
+    @Test
+    fun testExecuteWithContentAndToolCalls() = runTest {
+        //language=json
+        val bodyWithContentAndToolCalls = """
+            {
+              "id": "chatcmpl-content-and-tool",
+              "object": "chat.completion",
+              "created": 1716920005,
+              "system_fingerprint": "dummy",
+              "model": "deepseek-chat",
+              "choices": [
+                {
+                  "index": 0,
+                  "message": {
+                    "role": "assistant",
+                    "content": "I'll call the search tool to find the answer.",
+                    "tool_calls": [
+                      {
+                        "id": "call_abc123",
+                        "type": "function",
+                        "function": {
+                          "name": "search",
+                          "arguments": "{\"query\": \"Kotlin\"}"
+                        }
+                      }
+                    ]
+                  },
+                  "finish_reason": "tool_calls"
+                }
+              ],
+              "usage": {"total_tokens": 30, "prompt_tokens": 15, "completion_tokens": 15}
+            }
+        """.trimIndent()
+
+        val engine = MockEngine { _ ->
+            respond(
+                content = bodyWithContentAndToolCalls,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, Json.toString())
+            )
+        }
+        val http = HttpClient(engine) {}
+        val client = DeepSeekLLMClient(apiKey = key, baseClient = http, clock = FixedClock)
+        val prompt = Prompt.build(id = "p-content-tool", clock = FixedClock) { user("Search for Kotlin") }
+
+        val responses = client.execute(prompt, DeepSeekModels.DeepSeekChat)
+
+        assertEquals(2, responses.size, "Should return both the assistant content message and the tool call")
+        val assistantMsg = responses[0]
+        assertIs<Message.Assistant>(assistantMsg, "First response should be the assistant text content")
+        assertEquals("I'll call the search tool to find the answer.", assistantMsg.content)
+        val toolCall = responses[1]
+        assertIs<Message.Tool.Call>(toolCall, "Second response should be the tool call")
+        assertEquals("search", toolCall.tool)
+        assertEquals("{\"query\": \"Kotlin\"}", toolCall.content)
+    }
+
     @Test
     fun testResponseUsage() = runTest {
         val engine = MockEngine { _ ->

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
@@ -400,19 +400,29 @@ public abstract class AbstractOpenAILLMClient<TResponse : OpenAIBaseLLMResponse,
     ): List<Message.Response> {
         return when {
             this is OpenAIMessage.Assistant && !this.toolCalls.isNullOrEmpty() -> {
-                this.toolCalls.map { toolCall ->
-                    Message.Tool.Call(
-                        id = toolCall.id,
-                        tool = toolCall.function.name,
-                        /*
-                         If the tool has no arguments, OpenRouter puts an empty string in the arguments instead of an empty object
-                         But we always expect arguments to be a JSON object. Fixing this.
-                         */
-                        content = toolCall.function.arguments
-                            .takeIf { it.isNotEmpty() }
-                            ?: "{}",
-                        metaInfo = metaInfo
-                    )
+                buildList {
+                    // Some providers (e.g. DeepSeek) may return both content and toolCalls in the same response.
+                    // Include any text content before the tool calls to avoid context loss.
+                    this@toMessageResponses.reasoningContent?.let { reasoning ->
+                        add(Message.Reasoning(content = reasoning, metaInfo = metaInfo))
+                    }
+                    this@toMessageResponses.content?.text()?.takeIf { it.isNotEmpty() }?.let { text ->
+                        add(Message.Assistant(content = text, finishReason = finishReason, metaInfo = metaInfo))
+                    }
+                    addAll(this@toMessageResponses.toolCalls.map { toolCall ->
+                        Message.Tool.Call(
+                            id = toolCall.id,
+                            tool = toolCall.function.name,
+                            /*
+                             If the tool has no arguments, OpenRouter puts an empty string in the arguments instead of an empty object
+                             But we always expect arguments to be a JSON object. Fixing this.
+                             */
+                            content = toolCall.function.arguments
+                                .takeIf { it.isNotEmpty() }
+                                ?: "{}",
+                            metaInfo = metaInfo
+                        )
+                    })
                 }
             }
 


### PR DESCRIPTION
## Summary

Fixes #1589 (from [JetBrains/koog#1589](https://github.com/JetBrains/koog/issues/1589))

- **Root cause:** In `AbstractOpenAILLMClient.toMessageResponses()`, the first `when` branch matched any `OpenAIMessage.Assistant` with non-empty `toolCalls` and returned *only* the tool-call messages. Any `content` in the same response (e.g. a reasoning prefix from DeepSeek) was silently dropped.
- **Fix:** When `toolCalls` are present, we now also emit `reasoningContent` as `Message.Reasoning` and non-empty `content` as `Message.Assistant` *before* the tool-call messages, so no context is lost.
- **Test:** Added `testExecuteWithContentAndToolCalls` to `DeepSeekLLMClientTest` — a mocked response with both `content` and `tool_calls` — asserting both the assistant text message and the tool call are returned.

## Test plan
- [x] `./gradlew :prompt:prompt-executor:prompt-executor-clients:prompt-executor-deepseek-client:jvmTest` — all tests pass, including the new regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)