### PR TITLE
fix(message): replace lazy delegate in Message.Tool.Call with eager init to fix iOS crash

### DIFF
--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/config/MissingToolsConversionStrategyTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/config/MissingToolsConversionStrategyTest.kt
@@ -7,6 +7,7 @@ import ai.koog.prompt.message.RequestMetaInfo
 import ai.koog.prompt.message.ResponseMetaInfo
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.time.Clock
 import kotlin.time.Instant.Companion.fromEpochMilliseconds
@@ -212,6 +213,72 @@ class MissingToolsConversionStrategyTest {
 
         assertTrue(allStrategyResult.messages.isEmpty())
         assertTrue(missingStrategyResult.messages.isEmpty())
+    }
+
+    /**
+     * Regression test for https://github.com/DeniDoman/koog/issues/4
+     *
+     * On Kotlin/Native (iOS), `Message.Tool.Call.contentJsonResult` used `by lazy {}` with a
+     * `kotlin.Result<JsonObject>` return type. Since `kotlin.Result` is a value/inline class,
+     * its interaction with `SynchronizedLazyImpl` on Kotlin/Native caused crashes when accessing
+     * the underlying `JsonObject` (specifically at `HashMap#<get-entries>()`).
+     *
+     * Additionally, since `by lazy {}` is not a data property, calling `copy()` on a
+     * `Message.Tool.Call` produced a new instance with an uninitialized lazy delegate.
+     * When the `Missing` conversion strategy later called `describeToolCall()` on that copy
+     * (which accesses `contentJsonResult`), it would re-trigger lazy init and crash on iOS.
+     *
+     * The fix replaces `by lazy {}` with eager initialization, so `contentJsonResult` is always
+     * computed at construction time, including after `copy()`.
+     */
+    @Test
+    fun testContentJsonResultAccessibleAfterCopy() {
+        // Simulate what happens when token counts are updated: a copy is made with new metaInfo
+        val copiedToolCall = testToolCall.copy(metaInfo = ResponseMetaInfo.Empty)
+
+        // contentJsonResult must be accessible on the copy — this crashed on Kotlin/Native before the fix
+        assertTrue(copiedToolCall.contentJsonResult.isSuccess)
+        assertNotNull(copiedToolCall.contentJsonResult.getOrNull())
+        assertEquals(
+            testToolCall.contentJsonResult.getOrThrow(),
+            copiedToolCall.contentJsonResult.getOrThrow()
+        )
+    }
+
+    @Test
+    fun testConvertMessageWithCopiedToolCall() {
+        // Regression: describeToolCall() on a copied Message.Tool.Call crashed on Kotlin/Native
+        // because contentJsonResult used `by lazy {}`, which is not preserved across copy().
+        val copiedToolCall = testToolCall.copy(metaInfo = ResponseMetaInfo.Empty)
+
+        val result = allStrategy.convertMessage(copiedToolCall)
+        val expectedContent =
+            "{\"tool_call_id\":\"test-call-id\",\"tool_name\":\"test-tool\",\"tool_args\":{\"param\":\"value\"}}"
+
+        assertEquals(expectedContent, result.content)
+    }
+
+    @Test
+    fun testMissingStrategyConvertPromptWithCopiedToolCallAndEmptyTools() {
+        // Regression: simulates the nodeLLMRequest -> nodeExecuteTool -> nodeLLMRequestStructured
+        // flow where requestLLMStructured calls preparePrompt(prompt, emptyList()), which triggers
+        // the Missing strategy to convert all tool calls (including copies) via describeToolCall().
+        val copiedToolCall = testToolCall.copy(metaInfo = ResponseMetaInfo.Empty)
+        val testPrompt = prompt("test-prompt") {
+            user("User message")
+            tool {
+                call(copiedToolCall)
+            }
+        }
+
+        // With empty tools, all tool calls are "missing" and get converted
+        val result = missingStrategy.convertPrompt(testPrompt, emptyList())
+        val messages = result.messages
+
+        assertTrue(messages[1] is Message.Assistant)
+        val expectedContent =
+            "{\"tool_call_id\":\"test-call-id\",\"tool_name\":\"test-tool\",\"tool_args\":{\"param\":\"value\"}}"
+        assertEquals(expectedContent, messages[1].content)
     }
 
     @Test

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/message/Message.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/message/Message.kt
@@ -1,6 +1,7 @@
 package ai.koog.prompt.message
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
@@ -256,12 +257,17 @@ public sealed interface Message {
                 this(id, tool, ContentPart.Text(content), metaInfo)
 
             /**
-             * Lazily parses and caches the result of parsing [content] as a JSON object.
+             * Parses [content] as a JSON object, eagerly computed at construction time.
+             *
+             * Note: Using `by lazy {}` here causes crashes on Kotlin/Native (iOS) because
+             * `kotlin.Result<T>` (a value/inline class) does not work correctly with
+             * `SynchronizedLazyImpl` on Kotlin/Native targets. The lazy delegate is also
+             * not preserved on `copy()`, leading to unnecessary re-computation.
              */
             // TODO remove?
-            val contentJsonResult: kotlin.Result<JsonObject> by lazy {
+            @Transient
+            val contentJsonResult: kotlin.Result<JsonObject> =
                 runCatching { Json.parseToJsonElement(content).jsonObject }
-            }
 
             /**
              * Lazily parses the content of the tool call as a JSON object.


### PR DESCRIPTION
## Summary

- Fixes a crash on Kotlin/Native (iOS) at `HashMap#<get-entries>()` that occurs after a tool call in a graph flow of `nodeLLMRequest → nodeExecuteTool → nodeLLMRequestStructured`
- Root cause: `contentJsonResult: kotlin.Result<JsonObject> by lazy {}` in `Message.Tool.Call` — the `kotlin.Result` value/inline class does not work correctly with `SynchronizedLazyImpl` on Kotlin/Native, producing a corrupt `JsonObject` whose backing `LinkedHashMap.entries` crashes on access
- Secondary issue: `by lazy {}` is not a data property, so `copy()` creates a new instance with an uninitialized delegate; when `requestLLMStructured` calls `preparePrompt(prompt, emptyList())`, the `Missing` conversion strategy re-triggers lazy init on the copied instance
- Fix: replace `by lazy {}` with an eagerly-computed `@Transient val` so `contentJsonResult` is always correctly initialized at construction time, including after `copy()`

## Test plan

- [ ] `testContentJsonResultAccessibleAfterCopy` — verifies `contentJsonResult` is accessible and correct on a copied `Message.Tool.Call`
- [ ] `testConvertMessageWithCopiedToolCall` — verifies `describeToolCall()` works on a copied instance (regression for the crash path)
- [ ] `testMissingStrategyConvertPromptWithCopiedToolCallAndEmptyTools` — simulates the reported crash scenario end-to-end
- [ ] All existing `MissingToolsConversionStrategyTest` tests continue to pass
- [ ] Run `./gradlew :prompt:prompt-model:jvmTest :agents:agents-core:jvmTest`

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)