### PR TITLE
fix(ollama): handle AttachmentContent.URL in file converter

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaConverters.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaConverters.kt
@@ -87,7 +87,10 @@ private fun Message.User.toOllamaChatMessage(model: LLModel): OllamaChatMessageD
 
                         is AttachmentContent.Binary -> actualContent.asBase64()
 
-                        else -> throw IllegalArgumentException("Unsupported file attachment content: ${content::class}")
+                        is AttachmentContent.URL -> throw IllegalArgumentException(
+                            "Ollama does not support URL-based file attachments. " +
+                                "Use textFile() or binaryFile() to provide the file content directly."
+                        )
                     }
 
                     text.append("\n\n$fileContent")

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaConvertersTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaConvertersTest.kt
@@ -1,0 +1,105 @@
+package ai.koog.prompt.executor.ollama.client.dto
+
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.executor.ollama.client.OllamaModels
+import ai.koog.prompt.message.AttachmentContent
+import ai.koog.prompt.message.ContentPart
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class OllamaConvertersTest {
+
+    private val model = OllamaModels.Meta.LLAMA_3_2
+
+    @Test
+    fun testFileAttachmentWithPlainTextContent() {
+        val prompt = prompt("test") {
+            user {
+                text("Here is a file:")
+                file(
+                    ContentPart.File(
+                        content = AttachmentContent.PlainText("file content here"),
+                        format = "txt",
+                        mimeType = "text/plain",
+                        fileName = "test.txt"
+                    )
+                )
+            }
+        }
+
+        val messages = prompt.toOllamaChatMessages(model)
+        val userMessage = messages.first { it.role == "user" }
+
+        assertTrue(userMessage.content.contains("Here is a file:"))
+        assertTrue(userMessage.content.contains("file content here"))
+        assertNull(userMessage.images)
+    }
+
+    @Test
+    fun testFileAttachmentWithBinaryContent() {
+        val binaryData = "binary file data".encodeToByteArray()
+        val prompt = prompt("test") {
+            user {
+                text("Here is a binary file:")
+                file(
+                    ContentPart.File(
+                        content = AttachmentContent.Binary.Bytes(binaryData),
+                        format = "bin",
+                        mimeType = "application/octet-stream",
+                        fileName = "test.bin"
+                    )
+                )
+            }
+        }
+
+        val messages = prompt.toOllamaChatMessages(model)
+        val userMessage = messages.first { it.role == "user" }
+
+        assertTrue(userMessage.content.contains("Here is a binary file:"))
+        // Binary content should be base64 encoded
+        assertTrue(userMessage.content.length > "Here is a binary file:".length)
+        assertNull(userMessage.images)
+    }
+
+    @Test
+    fun testFileAttachmentWithUrlContentThrowsDescriptiveError() {
+        val prompt = prompt("test") {
+            user {
+                text("Here is a file:")
+                file(
+                    ContentPart.File(
+                        content = AttachmentContent.URL("https://example.com/file.pdf"),
+                        format = "pdf",
+                        mimeType = "application/pdf",
+                        fileName = "file.pdf"
+                    )
+                )
+            }
+        }
+
+        val exception = assertFailsWith<IllegalArgumentException> {
+            prompt.toOllamaChatMessages(model)
+        }
+
+        assertTrue(exception.message!!.contains("Ollama does not support URL-based file attachments"))
+        assertTrue(exception.message!!.contains("textFile()"))
+    }
+
+    @Test
+    fun testTextOnlyMessageConverts() {
+        val prompt = prompt("test") {
+            user("Hello, world!")
+        }
+
+        val messages = prompt.toOllamaChatMessages(model)
+        assertEquals(1, messages.size)
+
+        val userMessage = messages.first()
+        assertEquals("user", userMessage.role)
+        assertEquals("Hello, world!", userMessage.content)
+        assertNull(userMessage.images)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds explicit `AttachmentContent.URL` handling in Ollama's `toOllamaChatMessage` file attachment converter, replacing a misleading `else` branch that also had a variable reference bug (`content::class` instead of `actualContent::class`)
- Since Ollama runs locally and can't fetch remote URLs, the new branch throws a clear `IllegalArgumentException` guiding users to `textFile()` or `binaryFile()`
- Adds `OllamaConvertersTest` covering PlainText, Binary, and URL file attachment conversion

Closes #7

## Test plan
- [x] `OllamaConvertersTest.testFileAttachmentWithPlainTextContent` — verifies PlainText file content is appended to message
- [x] `OllamaConvertersTest.testFileAttachmentWithBinaryContent` — verifies Binary file content is base64 encoded
- [x] `OllamaConvertersTest.testFileAttachmentWithUrlContentThrowsDescriptiveError` — verifies URL content throws a descriptive error
- [x] `OllamaConvertersTest.testTextOnlyMessageConverts` — baseline text-only conversion
- [x] All tests pass on JVM and JS targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)