### PR TITLE
fix(memory): add TokenBudget to cap facts injected into LLM prompts

### DIFF
--- a/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/feature/AgentMemory.kt
+++ b/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/feature/AgentMemory.kt
@@ -27,6 +27,8 @@ import ai.koog.agents.memory.model.MemoryScope
 import ai.koog.agents.memory.model.MemorySubject
 import ai.koog.agents.memory.model.MultipleFacts
 import ai.koog.agents.memory.model.SingleFact
+import ai.koog.agents.memory.model.TokenBudget
+import ai.koog.agents.memory.model.estimateTokens
 import ai.koog.agents.memory.prompts.MemoryPrompts
 import ai.koog.agents.memory.providers.AgentMemoryProvider
 import ai.koog.agents.memory.providers.NoMemory
@@ -302,6 +304,8 @@ public class AgentMemory(
      * @param concept The concept to load facts about
      * @param scopes List of memory scopes to search in (Agent, Feature, etc.). By default all scopes are used.
      * @param subjects List of subjects to search in (User, Project, etc.). By default all registered subjects are used.
+     * @param tokenBudget Optional budget that caps the number of facts and/or approximate tokens
+     *                    injected into the prompt. By default there is no limit (backwards-compatible).
      */
     @OptIn(InternalAgentsApi::class)
     public suspend fun loadFactsToAgent(
@@ -309,7 +313,8 @@ public class AgentMemory(
         concept: Concept,
         scopes: List<MemoryScopeType> = MemoryScopeType.entries,
         subjects: List<MemorySubject> = MemorySubject.registeredSubjects,
-    ): Unit = loadFactsToAgentImpl(llm, scopes, subjects) { subject, scope ->
+        tokenBudget: TokenBudget = TokenBudget.Unlimited,
+    ): Unit = loadFactsToAgentImpl(llm, scopes, subjects, tokenBudget) { subject, scope ->
         agentMemory.load(concept, subject, scope)
     }
 
@@ -332,12 +337,15 @@ public class AgentMemory(
      * @param llm Current LLM context to interact with the agent's chat history.
      * @param scopes List of memory scopes to search in (Agent, Feature, etc.). By default all scopes are used.
      * @param subjects List of subjects to search in (User, Project, etc.). By default all registered subjects are used.
+     * @param tokenBudget Optional budget that caps the number of facts and/or approximate tokens
+     *                    injected into the prompt. By default there is no limit (backwards-compatible).
      */
     public suspend fun loadAllFactsToAgent(
         llm: AIAgentLLMContext,
         scopes: List<MemoryScopeType> = MemoryScopeType.entries,
         subjects: List<MemorySubject> = MemorySubject.registeredSubjects,
-    ): Unit = loadFactsToAgentImpl(llm, scopes, subjects, agentMemory::loadAll)
+        tokenBudget: TokenBudget = TokenBudget.Unlimited,
+    ): Unit = loadFactsToAgentImpl(llm, scopes, subjects, tokenBudget, agentMemory::loadAll)
 
     /**
      * Implementation method for loading facts from memory and adding them to the LLM chat history.
@@ -352,12 +360,14 @@ public class AgentMemory(
      * @param llm Current LLM context to interact with the agent's chat history
      * @param scopes List of memory scopes to search in
      * @param subjects List of subjects to search in
+     * @param tokenBudget Budget that caps the number of facts and/or approximate tokens injected
      * @param loadFacts Function that loads facts for a given subject and scope
      */
     private suspend fun loadFactsToAgentImpl(
         llm: AIAgentLLMContext,
         scopes: List<MemoryScopeType>,
         subjects: List<MemorySubject>,
+        tokenBudget: TokenBudget = TokenBudget.Unlimited,
         loadFacts: suspend (subject: MemorySubject, scope: MemoryScope) -> List<Fact>
     ) {
         // Load facts for all matching scopes
@@ -407,9 +417,12 @@ public class AgentMemory(
         // Add the most specific single facts to the result
         facts.addAll(singleFactsByKeyword.values.map { it.second })
 
-        val factsByConcept = facts.groupBy { it.concept }
+        // Apply token budget: prefer newer facts (higher timestamp) when trimming
+        val budgetedFacts = applyTokenBudget(facts, tokenBudget)
 
-        logger.info { "Found ${facts.size} facts for ${factsByConcept.size} concepts" }
+        val factsByConcept = budgetedFacts.groupBy { it.concept }
+
+        logger.info { "Found ${budgetedFacts.size} facts for ${factsByConcept.size} concepts (before budget: ${facts.size})" }
 
         // Add facts to LLM chat history
         if (factsByConcept.isNotEmpty()) {
@@ -440,8 +453,79 @@ public class AgentMemory(
                     logger.info { "Prompt updated" }
                 }
             }
-            logger.info { "Loaded ${facts.size} facts into LLM memory" }
+            logger.info { "Loaded ${budgetedFacts.size} facts into LLM memory" }
         }
+    }
+
+    /**
+     * Applies the token budget to a list of facts.
+     *
+     * Facts are sorted by timestamp descending (newest first) so that the most recent
+     * facts are preferred when the budget is exhausted. Both [TokenBudget.maxFacts] and
+     * [TokenBudget.maxTokens] are respected independently — whichever limit is hit first
+     * stops inclusion of further facts.
+     *
+     * For [MultipleFacts], individual values within a single fact entry are also trimmed
+     * to stay within the token budget.
+     */
+    internal fun applyTokenBudget(facts: List<Fact>, budget: TokenBudget): List<Fact> {
+        if (budget.maxFacts == null && budget.maxTokens == null) return facts
+
+        // Sort newest-first so we prefer recent facts
+        val sorted = facts.sortedByDescending { it.timestamp }
+
+        val result = mutableListOf<Fact>()
+        var factCount = 0
+        var tokenCount = 0
+
+        for (fact in sorted) {
+            if (budget.maxFacts != null && factCount >= budget.maxFacts) break
+
+            when (fact) {
+                is SingleFact -> {
+                    val tokens = fact.value.estimateTokens() + fact.concept.keyword.estimateTokens()
+                    if (budget.maxTokens != null && tokenCount + tokens > budget.maxTokens && result.isNotEmpty()) {
+                        break
+                    }
+                    result.add(fact)
+                    factCount++
+                    tokenCount += tokens
+                }
+
+                is MultipleFacts -> {
+                    if (budget.maxTokens != null) {
+                        // Include as many values as fit within the token budget
+                        val includedValues = mutableListOf<String>()
+                        val headerTokens = fact.concept.keyword.estimateTokens()
+                        var entryTokens = headerTokens
+
+                        for (value in fact.values) {
+                            val valueTokens = value.estimateTokens()
+                            if (tokenCount + entryTokens + valueTokens > budget.maxTokens && includedValues.isNotEmpty()) {
+                                break
+                            }
+                            includedValues.add(value)
+                            entryTokens += valueTokens
+                        }
+
+                        if (includedValues.isNotEmpty()) {
+                            result.add(fact.copy(values = includedValues))
+                            factCount++
+                            tokenCount += entryTokens
+                        }
+                    } else {
+                        result.add(fact)
+                        factCount++
+                    }
+                }
+            }
+        }
+
+        if (result.size < facts.size) {
+            logger.info { "Token budget trimmed facts from ${facts.size} to ${result.size} (budget: $budget)" }
+        }
+
+        return result
     }
 }
 

--- a/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/feature/nodes/MemoryNodes.kt
+++ b/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/feature/nodes/MemoryNodes.kt
@@ -12,6 +12,7 @@ import ai.koog.agents.memory.model.FactType
 import ai.koog.agents.memory.model.MemorySubject
 import ai.koog.agents.memory.model.MultipleFacts
 import ai.koog.agents.memory.model.SingleFact
+import ai.koog.agents.memory.model.TokenBudget
 import ai.koog.agents.memory.prompts.MemoryPrompts
 import ai.koog.prompt.llm.LLModel
 import kotlinx.serialization.Serializable
@@ -28,14 +29,16 @@ import kotlin.time.Clock
  * @param subject The subject scope of the memory (USER, PROJECT, etc.)
  * @param scope The scope of the memory (Agent, Feature, etc.)
  * @param concept A concept to load facts for
+ * @param tokenBudget Optional budget that caps the number of facts and/or approximate tokens injected into the prompt
  */
 @AIAgentBuilderDslMarker
 public inline fun <reified T> nodeLoadFromMemory(
     name: String? = null,
     concept: Concept,
     subject: MemorySubject,
-    scope: MemoryScopeType = MemoryScopeType.AGENT
-): AIAgentNodeDelegate<T, T> = nodeLoadFromMemory(name, listOf(concept), listOf(subject), listOf(scope))
+    scope: MemoryScopeType = MemoryScopeType.AGENT,
+    tokenBudget: TokenBudget = TokenBudget.Unlimited
+): AIAgentNodeDelegate<T, T> = nodeLoadFromMemory(name, listOf(concept), listOf(subject), listOf(scope), tokenBudget)
 
 /**
  * Node that loads facts from memory for a given concept
@@ -43,14 +46,16 @@ public inline fun <reified T> nodeLoadFromMemory(
  * @param subject The subject scope of the memory (USER, PROJECT, etc.)
  * @param scope The scope of the memory (Agent, Feature, etc.)
  * @param concepts A list of concepts to load facts for
+ * @param tokenBudget Optional budget that caps the number of facts and/or approximate tokens injected into the prompt
  */
 @AIAgentBuilderDslMarker
 public inline fun <reified T> nodeLoadFromMemory(
     name: String? = null,
     concepts: List<Concept>,
     subject: MemorySubject,
-    scope: MemoryScopeType = MemoryScopeType.AGENT
-): AIAgentNodeDelegate<T, T> = nodeLoadFromMemory(name, concepts, listOf(subject), listOf(scope))
+    scope: MemoryScopeType = MemoryScopeType.AGENT,
+    tokenBudget: TokenBudget = TokenBudget.Unlimited
+): AIAgentNodeDelegate<T, T> = nodeLoadFromMemory(name, concepts, listOf(subject), listOf(scope), tokenBudget)
 
 /**
  * Node that loads facts from memory for a given concept
@@ -58,6 +63,7 @@ public inline fun <reified T> nodeLoadFromMemory(
  * @param concepts A list of concepts to load facts for
  * @param scopes List of memory scopes (Agent, Feature, etc.). By default all scopes would be chosen
  * @param subjects List of subjects (user, project, organization, etc.) to look for. By default all subjects would be chosen
+ * @param tokenBudget Optional budget that caps the number of facts and/or approximate tokens injected into the prompt
  */
 @OptIn(InternalAgentsApi::class)
 @AIAgentBuilderDslMarker
@@ -65,11 +71,12 @@ public inline fun <reified T> nodeLoadFromMemory(
     name: String? = null,
     concepts: List<Concept>,
     subjects: List<MemorySubject> = MemorySubject.registeredSubjects,
-    scopes: List<MemoryScopeType> = MemoryScopeType.entries
+    scopes: List<MemoryScopeType> = MemoryScopeType.entries,
+    tokenBudget: TokenBudget = TokenBudget.Unlimited
 ): AIAgentNodeDelegate<T, T> = node(name) { input ->
     withMemory {
         concepts.forEach { concept ->
-            loadFactsToAgent(llm, concept, scopes, subjects)
+            loadFactsToAgent(llm, concept, scopes, subjects, tokenBudget)
         }
     }
 
@@ -81,16 +88,18 @@ public inline fun <reified T> nodeLoadFromMemory(
  *
  * @param scopes List of memory scopes (Agent, Feature, etc.). By default only Agent scope would be chosen
  * @param subjects List of subjects (user, project, organization, etc.) to look for.
+ * @param tokenBudget Optional budget that caps the number of facts and/or approximate tokens injected into the prompt
  */
 @OptIn(InternalAgentsApi::class)
 @AIAgentBuilderDslMarker
 public inline fun <reified T> nodeLoadAllFactsFromMemory(
     name: String? = null,
     subjects: List<MemorySubject> = MemorySubject.registeredSubjects,
-    scopes: List<MemoryScopeType> = MemoryScopeType.entries
+    scopes: List<MemoryScopeType> = MemoryScopeType.entries,
+    tokenBudget: TokenBudget = TokenBudget.Unlimited
 ): AIAgentNodeDelegate<T, T> = node(name) { input ->
     withMemory {
-        loadAllFactsToAgent(llm, scopes, subjects)
+        loadAllFactsToAgent(llm, scopes, subjects, tokenBudget)
     }
 
     input

--- a/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/model/TokenBudget.kt
+++ b/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/model/TokenBudget.kt
@@ -1,0 +1,51 @@
+package ai.koog.agents.memory.model
+
+/**
+ * Controls how many facts (and approximate tokens) are injected into the LLM
+ * prompt when loading from memory.
+ *
+ * Both limits are optional and applied independently — whichever is hit first wins.
+ * When neither is set, the budget is effectively unlimited (backwards-compatible default).
+ *
+ * Token estimation uses a simple heuristic of ~4 characters per token, which is
+ * a reasonable approximation for English text across most tokenizers.
+ *
+ * Example usage:
+ * ```kotlin
+ * // Cap at 20 fact entries and ~4000 tokens
+ * val budget = TokenBudget(maxFacts = 20, maxTokens = 4000)
+ *
+ * memory.loadAllFactsToAgent(
+ *     llm = llm,
+ *     tokenBudget = budget
+ * )
+ * ```
+ *
+ * @property maxFacts Maximum number of individual fact entries to inject. `null` means unlimited.
+ * @property maxTokens Approximate upper bound on injected tokens. `null` means unlimited.
+ */
+public data class TokenBudget(
+    val maxFacts: Int? = null,
+    val maxTokens: Int? = null,
+) {
+    init {
+        require(maxFacts == null || maxFacts > 0) { "maxFacts must be positive, got $maxFacts" }
+        require(maxTokens == null || maxTokens > 0) { "maxTokens must be positive, got $maxTokens" }
+    }
+
+    public companion object {
+        /**
+         * No limits — all loaded facts are injected. This is the default, preserving
+         * existing behaviour for callers that don't opt in to budgeting.
+         */
+        public val Unlimited: TokenBudget = TokenBudget()
+
+        /** Rough characters-per-token ratio used for estimation. */
+        internal const val CHARS_PER_TOKEN: Int = 4
+    }
+}
+
+/**
+ * Estimates the token count of a string using a simple character-based heuristic.
+ */
+internal fun String.estimateTokens(): Int = (length + TokenBudget.CHARS_PER_TOKEN - 1) / TokenBudget.CHARS_PER_TOKEN

--- a/agents/agents-features/agents-features-memory/src/jvmTest/kotlin/ai/koog/agents/memory/TokenBudgetTest.kt
+++ b/agents/agents-features/agents-features-memory/src/jvmTest/kotlin/ai/koog/agents/memory/TokenBudgetTest.kt
@@ -1,0 +1,381 @@
+package ai.koog.agents.memory
+
+import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.agent.context.AIAgentLLMContext
+import ai.koog.agents.core.annotation.InternalAgentsApi
+import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.memory.config.MemoryScopeType
+import ai.koog.agents.memory.config.MemoryScopesProfile
+import ai.koog.agents.memory.feature.AgentMemory
+import ai.koog.agents.memory.model.Concept
+import ai.koog.agents.memory.model.FactType
+import ai.koog.agents.memory.model.MemoryScope
+import ai.koog.agents.memory.model.MemorySubject
+import ai.koog.agents.memory.model.MultipleFacts
+import ai.koog.agents.memory.model.SingleFact
+import ai.koog.agents.memory.model.TokenBudget
+import ai.koog.agents.memory.model.estimateTokens
+import ai.koog.agents.memory.providers.AgentMemoryProvider
+import ai.koog.agents.testing.tools.MockEnvironment
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.executor.model.PromptExecutor
+import ai.koog.prompt.llm.LLMProvider
+import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.message.Message
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.Serializable
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+@OptIn(InternalAgentsApi::class)
+class TokenBudgetTest {
+
+    @Serializable
+    data object UserSubject : MemorySubject() {
+        override val name: String = "user"
+        override val promptDescription: String = "User preferences"
+        override val priorityLevel: Int = 2
+    }
+
+    private val testModel = mockk<LLModel> {
+        every { id } returns "test-model"
+        every { provider } returns mockk<LLMProvider>()
+    }
+
+    private val testClock: Clock = object : Clock {
+        override fun now(): Instant = Instant.parse("2023-01-01T00:00:00Z")
+    }
+
+    // -- TokenBudget unit tests --
+
+    @Test
+    fun testTokenBudgetValidation() {
+        assertFailsWith<IllegalArgumentException> { TokenBudget(maxFacts = 0) }
+        assertFailsWith<IllegalArgumentException> { TokenBudget(maxFacts = -1) }
+        assertFailsWith<IllegalArgumentException> { TokenBudget(maxTokens = 0) }
+        assertFailsWith<IllegalArgumentException> { TokenBudget(maxTokens = -5) }
+
+        // Valid budgets should not throw
+        TokenBudget(maxFacts = 1, maxTokens = 1)
+        TokenBudget.Unlimited
+    }
+
+    @Test
+    fun testEstimateTokens() {
+        assertEquals(0, "".estimateTokens())
+        assertEquals(1, "abc".estimateTokens()) // 3 chars / 4 = 0.75 rounds up to 1
+        assertEquals(1, "abcd".estimateTokens()) // 4 chars / 4 = 1
+        assertEquals(3, "Hello world!".estimateTokens()) // 12 chars / 4 = 3
+    }
+
+    // -- applyTokenBudget unit tests --
+
+    @Test
+    fun testApplyTokenBudgetUnlimitedReturnsAllFacts() {
+        val concept = Concept("test", "desc", FactType.SINGLE)
+        val facts = (1..100).map {
+            SingleFact(concept = concept, value = "Fact number $it with some text", timestamp = it.toLong())
+        }
+
+        val memory = AgentMemory(
+            agentMemory = mockk(),
+            scopesProfile = MemoryScopesProfile()
+        )
+
+        val result = memory.applyTokenBudget(facts, TokenBudget.Unlimited)
+        assertEquals(100, result.size, "Unlimited budget should return all facts")
+    }
+
+    @Test
+    fun testApplyTokenBudgetMaxFactsCapsCount() {
+        val concept = Concept("test", "desc", FactType.SINGLE)
+        val facts = (1..20).map {
+            SingleFact(concept = concept, value = "Fact $it", timestamp = it.toLong())
+        }
+
+        val memory = AgentMemory(
+            agentMemory = mockk(),
+            scopesProfile = MemoryScopesProfile()
+        )
+
+        val result = memory.applyTokenBudget(facts, TokenBudget(maxFacts = 5))
+        assertEquals(5, result.size, "Should cap at maxFacts=5")
+        // Should prefer newest facts (highest timestamps)
+        assertTrue(result.all { (it as SingleFact).timestamp >= 16 },
+            "Should keep the 5 most recent facts (timestamps 16-20)")
+    }
+
+    @Test
+    fun testApplyTokenBudgetMaxTokensCapsContent() {
+        val concept = Concept("k", "desc", FactType.SINGLE)
+        // Each fact: keyword "k" (1 token) + value "x".repeat(40) (10 tokens) = ~11 tokens
+        val facts = (1..10).map {
+            SingleFact(concept = concept, value = "x".repeat(40), timestamp = it.toLong())
+        }
+
+        val memory = AgentMemory(
+            agentMemory = mockk(),
+            scopesProfile = MemoryScopesProfile()
+        )
+
+        // Budget for ~25 tokens should fit about 2 facts (each ~11 tokens)
+        val result = memory.applyTokenBudget(facts, TokenBudget(maxTokens = 25))
+        assertTrue(result.size in 1..3, "Should include ~2 facts within 25 token budget, got ${result.size}")
+    }
+
+    @Test
+    fun testApplyTokenBudgetPrefersNewerFacts() {
+        val concept = Concept("test", "desc", FactType.SINGLE)
+        val facts = listOf(
+            SingleFact(concept = concept, value = "old fact", timestamp = 100L),
+            SingleFact(concept = concept, value = "newer fact", timestamp = 200L),
+            SingleFact(concept = concept, value = "newest fact", timestamp = 300L),
+        )
+
+        val memory = AgentMemory(
+            agentMemory = mockk(),
+            scopesProfile = MemoryScopesProfile()
+        )
+
+        val result = memory.applyTokenBudget(facts, TokenBudget(maxFacts = 2))
+        assertEquals(2, result.size)
+        assertEquals(300L, result[0].timestamp, "First should be newest")
+        assertEquals(200L, result[1].timestamp, "Second should be second-newest")
+    }
+
+    @Test
+    fun testApplyTokenBudgetTrimsMultipleFactsValues() {
+        val concept = Concept("items", "desc", FactType.MULTIPLE)
+        val fact = MultipleFacts(
+            concept = concept,
+            values = (1..50).map { "Item number $it with a moderately long description text" },
+            timestamp = 1L
+        )
+
+        val memory = AgentMemory(
+            agentMemory = mockk(),
+            scopesProfile = MemoryScopesProfile()
+        )
+
+        // Very tight token budget should trim values within the MultipleFacts
+        val result = memory.applyTokenBudget(listOf(fact), TokenBudget(maxTokens = 100))
+        assertTrue(result.isNotEmpty(), "Should include at least the fact")
+        val trimmed = result.first() as MultipleFacts
+        assertTrue(trimmed.values.size < 50,
+            "Should trim values within MultipleFacts, got ${trimmed.values.size}")
+    }
+
+    // -- Integration test: reproduces the bug scenario from the issue --
+
+    @Test
+    fun testUnboundedFactGrowthWithoutBudget() = runTest {
+        // Simulate the CustomerSupportAgent scenario: 12 sessions, ~4 MultipleFacts each
+        val sessionsCount = 12
+        val conceptsPerSession = listOf(
+            Concept("user-preferences", "User communication preferences", FactType.MULTIPLE),
+            Concept("user-issues", "Issue descriptions and resolutions", FactType.MULTIPLE),
+            Concept("diagnostic-results", "Device diagnostics and error codes", FactType.MULTIPLE),
+            Concept("organization-solutions", "Organization-wide solutions", FactType.MULTIPLE),
+        )
+
+        val allFacts = mutableListOf<MultipleFacts>()
+        for (session in 1..sessionsCount) {
+            for (concept in conceptsPerSession) {
+                allFacts.add(
+                    MultipleFacts(
+                        concept = concept,
+                        values = listOf(
+                            "Session $session detail 1 for ${concept.keyword}: some moderately long text describing the fact",
+                            "Session $session detail 2 for ${concept.keyword}: another piece of relevant information here",
+                            "Session $session detail 3 for ${concept.keyword}: yet more context that the agent remembered",
+                        ),
+                        timestamp = (session * 1000).toLong()
+                    )
+                )
+            }
+        }
+
+        // Total: 12 sessions * 4 concepts * 3 values = 144 individual fact values
+        assertEquals(48, allFacts.size, "Should have 48 MultipleFacts entries (12 sessions * 4 concepts)")
+
+        val memoryProvider = mockk<AgentMemoryProvider>()
+        coEvery { memoryProvider.loadAll(any(), any()) } returns allFacts
+
+        val promptExecutor = mockk<PromptExecutor>()
+        val capturedPrompts = mutableListOf<Prompt>()
+        coEvery { promptExecutor.execute(capture(capturedPrompts), any()) } returns listOf(
+            mockk<Message.Response> { every { content } returns "OK" }
+        )
+
+        val llm = AIAgentLLMContext(
+            tools = emptyList(),
+            prompt = prompt("test") {},
+            model = testModel,
+            responseProcessor = null,
+            promptExecutor = promptExecutor,
+            environment = MockEnvironment(ToolRegistry.EMPTY, promptExecutor, ai.koog.serialization.kotlinx.KotlinxSerializer()),
+            config = AIAgentConfig(Prompt.Empty, testModel, 100),
+            clock = testClock
+        )
+
+        val memory = AgentMemory(
+            agentMemory = memoryProvider,
+            scopesProfile = MemoryScopesProfile(MemoryScopeType.AGENT to "test-agent")
+        )
+
+        // WITHOUT budget: all 48 fact entries are loaded, producing a very large prompt
+        memory.loadAllFactsToAgent(
+            llm = llm,
+            scopes = listOf(MemoryScopeType.AGENT),
+            subjects = listOf(UserSubject),
+        )
+
+        // Measure the injected content by reading the prompt messages
+        val promptMessages = llm.readSession { prompt.messages }
+        val totalContent = promptMessages.joinToString("\n") { it.content }
+        val totalChars = totalContent.length
+
+        // Issue states ~8000 tokens (>32000 chars) for 12 sessions — verify it's large
+        assertTrue(totalChars > 5000,
+            "Without budget, injected content should be large (was $totalChars chars)")
+    }
+
+    @Test
+    fun testTokenBudgetCapsFactsInLoadAllFactsToAgent() = runTest {
+        // Same setup as above but WITH a token budget
+        val sessionsCount = 12
+        val conceptsPerSession = listOf(
+            Concept("user-preferences", "User communication preferences", FactType.MULTIPLE),
+            Concept("user-issues", "Issue descriptions and resolutions", FactType.MULTIPLE),
+            Concept("diagnostic-results", "Device diagnostics and error codes", FactType.MULTIPLE),
+            Concept("organization-solutions", "Organization-wide solutions", FactType.MULTIPLE),
+        )
+
+        val allFacts = mutableListOf<MultipleFacts>()
+        for (session in 1..sessionsCount) {
+            for (concept in conceptsPerSession) {
+                allFacts.add(
+                    MultipleFacts(
+                        concept = concept,
+                        values = listOf(
+                            "Session $session detail 1 for ${concept.keyword}: some moderately long text describing the fact",
+                            "Session $session detail 2 for ${concept.keyword}: another piece of relevant information here",
+                            "Session $session detail 3 for ${concept.keyword}: yet more context that the agent remembered",
+                        ),
+                        timestamp = (session * 1000).toLong()
+                    )
+                )
+            }
+        }
+
+        val memoryProvider = mockk<AgentMemoryProvider>()
+        coEvery { memoryProvider.loadAll(any(), any()) } returns allFacts
+
+        val promptExecutor = mockk<PromptExecutor>()
+        coEvery { promptExecutor.execute(any(), any()) } returns listOf(
+            mockk<Message.Response> { every { content } returns "OK" }
+        )
+
+        val llm = AIAgentLLMContext(
+            tools = emptyList(),
+            prompt = prompt("test") {},
+            model = testModel,
+            responseProcessor = null,
+            promptExecutor = promptExecutor,
+            environment = MockEnvironment(ToolRegistry.EMPTY, promptExecutor, ai.koog.serialization.kotlinx.KotlinxSerializer()),
+            config = AIAgentConfig(Prompt.Empty, testModel, 100),
+            clock = testClock
+        )
+
+        val memory = AgentMemory(
+            agentMemory = memoryProvider,
+            scopesProfile = MemoryScopesProfile(MemoryScopeType.AGENT to "test-agent")
+        )
+
+        // WITH budget: cap at 8 facts and ~2000 tokens
+        memory.loadAllFactsToAgent(
+            llm = llm,
+            scopes = listOf(MemoryScopeType.AGENT),
+            subjects = listOf(UserSubject),
+            tokenBudget = TokenBudget(maxFacts = 8, maxTokens = 2000)
+        )
+
+        val promptMessages = llm.readSession { prompt.messages }
+        val totalContent = promptMessages.joinToString("\n") { it.content }
+        val totalChars = totalContent.length
+        val estimatedTokens = totalContent.estimateTokens()
+
+        // Verify budget is respected
+        assertTrue(estimatedTokens <= 2500,
+            "With token budget of 2000, estimated tokens should be capped (was $estimatedTokens)")
+        assertTrue(totalChars < 10000,
+            "With budget, injected content should be much smaller (was $totalChars chars)")
+    }
+
+    @Test
+    fun testTokenBudgetCapsFactsInLoadFactsToAgent() = runTest {
+        val concept = Concept("user-issues", "Issue descriptions", FactType.MULTIPLE)
+        val facts = (1..20).map { session ->
+            MultipleFacts(
+                concept = concept,
+                values = listOf("Issue from session $session: detailed description of the problem"),
+                timestamp = (session * 1000).toLong()
+            )
+        }
+
+        val memoryProvider = mockk<AgentMemoryProvider>()
+        coEvery { memoryProvider.load(concept, any(), any()) } returns facts
+
+        val promptExecutor = mockk<PromptExecutor>()
+        coEvery { promptExecutor.execute(any(), any()) } returns listOf(
+            mockk<Message.Response> { every { content } returns "OK" }
+        )
+
+        val llm = AIAgentLLMContext(
+            tools = emptyList(),
+            prompt = prompt("test") {},
+            model = testModel,
+            responseProcessor = null,
+            promptExecutor = promptExecutor,
+            environment = MockEnvironment(ToolRegistry.EMPTY, promptExecutor, ai.koog.serialization.kotlinx.KotlinxSerializer()),
+            config = AIAgentConfig(Prompt.Empty, testModel, 100),
+            clock = testClock
+        )
+
+        val memory = AgentMemory(
+            agentMemory = memoryProvider,
+            scopesProfile = MemoryScopesProfile(MemoryScopeType.AGENT to "test-agent")
+        )
+
+        // Load with budget of max 5 facts
+        memory.loadFactsToAgent(
+            llm = llm,
+            concept = concept,
+            scopes = listOf(MemoryScopeType.AGENT),
+            subjects = listOf(UserSubject),
+            tokenBudget = TokenBudget(maxFacts = 5)
+        )
+
+        val promptMessages = llm.readSession { prompt.messages }
+        val totalContent = promptMessages.joinToString("\n") { it.content }
+
+        // With 20 facts capped at 5, only the 5 newest sessions (16-20) should appear
+        for (session in 16..20) {
+            assertTrue(totalContent.contains("session $session:"),
+                "Should contain newest session $session")
+        }
+        // Use "session N:" pattern to avoid matching "session 1" inside "session 10"
+        for (session in 1..9) {
+            assertTrue(!totalContent.contains("session $session:"),
+                "Should NOT contain old session $session")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `TokenBudget(maxFacts, maxTokens)` to cap the number of facts and approximate tokens injected into the LLM prompt when loading from memory
- Applies budget in `loadFactsToAgentImpl` after fact collection/prioritization, preferring newest facts (sorted by timestamp descending) when trimming
- Propagates the optional `tokenBudget` parameter through `loadFactsToAgent`, `loadAllFactsToAgent`, `nodeLoadFromMemory`, and `nodeLoadAllFactsFromMemory` DSL nodes
- Default is `TokenBudget.Unlimited` — existing behavior is fully preserved for callers that don't opt in

Closes #9

## Test plan

- [x] Unit tests for `TokenBudget` validation (rejects non-positive values)
- [x] Unit tests for `estimateTokens` heuristic
- [x] Unit tests for `applyTokenBudget` with `maxFacts`, `maxTokens`, newest-first preference, and `MultipleFacts` value trimming
- [x] Integration test reproducing unbounded growth (12 sessions × 4 concepts = 48 MultipleFacts, >5000 chars without budget)
- [x] Integration test verifying `loadAllFactsToAgent` respects `TokenBudget(maxFacts=8, maxTokens=2000)`
- [x] Integration test verifying `loadFactsToAgent` with `maxFacts=5` drops old sessions and keeps newest
- [x] All 78 existing tests in agents-features-memory continue to pass
- [x] Full module builds successfully on JVM, JS, and WASM targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)