### PR TITLE
fix(memory): add maxFacts limit to prevent context window overflow

### DIFF
--- a/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/feature/AgentMemory.kt
+++ b/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/feature/AgentMemory.kt
@@ -294,7 +294,8 @@ public class AgentMemory(
      * memory.loadFactsToAgent(
      *     concept = Concept("preferred-language", "User's preferred programming language"),
      *     scopes = listOf(MemoryScopeType.PRODUCT, MemoryScopeType.AGENT),
-     *     subjects = listOf(MemorySubjects.User)
+     *     subjects = listOf(MemorySubjects.User),
+     *     maxFacts = 20
      * )
      * ```
      *
@@ -302,6 +303,8 @@ public class AgentMemory(
      * @param concept The concept to load facts about
      * @param scopes List of memory scopes to search in (Agent, Feature, etc.). By default all scopes are used.
      * @param subjects List of subjects to search in (User, Project, etc.). By default all registered subjects are used.
+     * @param maxFacts Maximum number of facts to inject into the prompt. Defaults to [Int.MAX_VALUE] (no limit).
+     *                 Use this to prevent context window overflow when memory grows large across many sessions.
      */
     @OptIn(InternalAgentsApi::class)
     public suspend fun loadFactsToAgent(
@@ -309,7 +312,8 @@ public class AgentMemory(
         concept: Concept,
         scopes: List<MemoryScopeType> = MemoryScopeType.entries,
         subjects: List<MemorySubject> = MemorySubject.registeredSubjects,
-    ): Unit = loadFactsToAgentImpl(llm, scopes, subjects) { subject, scope ->
+        maxFacts: Int = Int.MAX_VALUE,
+    ): Unit = loadFactsToAgentImpl(llm, scopes, subjects, maxFacts) { subject, scope ->
         agentMemory.load(concept, subject, scope)
     }
 
@@ -325,19 +329,23 @@ public class AgentMemory(
      * // Load all project-related facts from the product scope
      * memory.loadAllFactsToAgent(
      *     scopes = listOf(MemoryScopeType.PRODUCT),
-     *     subjects = listOf(MemorySubjects.Project)
+     *     subjects = listOf(MemorySubjects.Project),
+     *     maxFacts = 50
      * )
      * ```
      *
      * @param llm Current LLM context to interact with the agent's chat history.
      * @param scopes List of memory scopes to search in (Agent, Feature, etc.). By default all scopes are used.
      * @param subjects List of subjects to search in (User, Project, etc.). By default all registered subjects are used.
+     * @param maxFacts Maximum number of facts to inject into the prompt. Defaults to [Int.MAX_VALUE] (no limit).
+     *                 Use this to prevent context window overflow when memory grows large across many sessions.
      */
     public suspend fun loadAllFactsToAgent(
         llm: AIAgentLLMContext,
         scopes: List<MemoryScopeType> = MemoryScopeType.entries,
         subjects: List<MemorySubject> = MemorySubject.registeredSubjects,
-    ): Unit = loadFactsToAgentImpl(llm, scopes, subjects, agentMemory::loadAll)
+        maxFacts: Int = Int.MAX_VALUE,
+    ): Unit = loadFactsToAgentImpl(llm, scopes, subjects, maxFacts, agentMemory::loadAll)
 
     /**
      * Implementation method for loading facts from memory and adding them to the LLM chat history.
@@ -352,12 +360,14 @@ public class AgentMemory(
      * @param llm Current LLM context to interact with the agent's chat history
      * @param scopes List of memory scopes to search in
      * @param subjects List of subjects to search in
+     * @param maxFacts Maximum number of facts to inject into the prompt
      * @param loadFacts Function that loads facts for a given subject and scope
      */
     private suspend fun loadFactsToAgentImpl(
         llm: AIAgentLLMContext,
         scopes: List<MemoryScopeType>,
         subjects: List<MemorySubject>,
+        maxFacts: Int,
         loadFacts: suspend (subject: MemorySubject, scope: MemoryScope) -> List<Fact>
     ) {
         // Load facts for all matching scopes
@@ -407,9 +417,16 @@ public class AgentMemory(
         // Add the most specific single facts to the result
         facts.addAll(singleFactsByKeyword.values.map { it.second })
 
-        val factsByConcept = facts.groupBy { it.concept }
+        val limitedFacts = if (maxFacts < facts.size) {
+            logger.info { "Limiting facts from ${facts.size} to $maxFacts due to maxFacts cap" }
+            facts.take(maxFacts)
+        } else {
+            facts
+        }
 
-        logger.info { "Found ${facts.size} facts for ${factsByConcept.size} concepts" }
+        val factsByConcept = limitedFacts.groupBy { it.concept }
+
+        logger.info { "Found ${limitedFacts.size} facts for ${factsByConcept.size} concepts (${facts.size} total before limit)" }
 
         // Add facts to LLM chat history
         if (factsByConcept.isNotEmpty()) {
@@ -440,7 +457,7 @@ public class AgentMemory(
                     logger.info { "Prompt updated" }
                 }
             }
-            logger.info { "Loaded ${facts.size} facts into LLM memory" }
+            logger.info { "Loaded ${limitedFacts.size} facts into LLM memory" }
         }
     }
 }

--- a/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/feature/nodes/MemoryNodes.kt
+++ b/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/feature/nodes/MemoryNodes.kt
@@ -28,14 +28,16 @@ import kotlin.time.Clock
  * @param subject The subject scope of the memory (USER, PROJECT, etc.)
  * @param scope The scope of the memory (Agent, Feature, etc.)
  * @param concept A concept to load facts for
+ * @param maxFacts Maximum number of facts to inject into the prompt. Defaults to [Int.MAX_VALUE] (no limit).
  */
 @AIAgentBuilderDslMarker
 public inline fun <reified T> nodeLoadFromMemory(
     name: String? = null,
     concept: Concept,
     subject: MemorySubject,
-    scope: MemoryScopeType = MemoryScopeType.AGENT
-): AIAgentNodeDelegate<T, T> = nodeLoadFromMemory(name, listOf(concept), listOf(subject), listOf(scope))
+    scope: MemoryScopeType = MemoryScopeType.AGENT,
+    maxFacts: Int = Int.MAX_VALUE,
+): AIAgentNodeDelegate<T, T> = nodeLoadFromMemory(name, listOf(concept), listOf(subject), listOf(scope), maxFacts)
 
 /**
  * Node that loads facts from memory for a given concept
@@ -43,14 +45,16 @@ public inline fun <reified T> nodeLoadFromMemory(
  * @param subject The subject scope of the memory (USER, PROJECT, etc.)
  * @param scope The scope of the memory (Agent, Feature, etc.)
  * @param concepts A list of concepts to load facts for
+ * @param maxFacts Maximum number of facts to inject into the prompt. Defaults to [Int.MAX_VALUE] (no limit).
  */
 @AIAgentBuilderDslMarker
 public inline fun <reified T> nodeLoadFromMemory(
     name: String? = null,
     concepts: List<Concept>,
     subject: MemorySubject,
-    scope: MemoryScopeType = MemoryScopeType.AGENT
-): AIAgentNodeDelegate<T, T> = nodeLoadFromMemory(name, concepts, listOf(subject), listOf(scope))
+    scope: MemoryScopeType = MemoryScopeType.AGENT,
+    maxFacts: Int = Int.MAX_VALUE,
+): AIAgentNodeDelegate<T, T> = nodeLoadFromMemory(name, concepts, listOf(subject), listOf(scope), maxFacts)
 
 /**
  * Node that loads facts from memory for a given concept
@@ -58,6 +62,8 @@ public inline fun <reified T> nodeLoadFromMemory(
  * @param concepts A list of concepts to load facts for
  * @param scopes List of memory scopes (Agent, Feature, etc.). By default all scopes would be chosen
  * @param subjects List of subjects (user, project, organization, etc.) to look for. By default all subjects would be chosen
+ * @param maxFacts Maximum number of facts to inject into the prompt. Defaults to [Int.MAX_VALUE] (no limit).
+ *                 Use this to prevent context window overflow when memory grows large across many sessions.
  */
 @OptIn(InternalAgentsApi::class)
 @AIAgentBuilderDslMarker
@@ -65,11 +71,12 @@ public inline fun <reified T> nodeLoadFromMemory(
     name: String? = null,
     concepts: List<Concept>,
     subjects: List<MemorySubject> = MemorySubject.registeredSubjects,
-    scopes: List<MemoryScopeType> = MemoryScopeType.entries
+    scopes: List<MemoryScopeType> = MemoryScopeType.entries,
+    maxFacts: Int = Int.MAX_VALUE,
 ): AIAgentNodeDelegate<T, T> = node(name) { input ->
     withMemory {
         concepts.forEach { concept ->
-            loadFactsToAgent(llm, concept, scopes, subjects)
+            loadFactsToAgent(llm, concept, scopes, subjects, maxFacts)
         }
     }
 
@@ -81,16 +88,19 @@ public inline fun <reified T> nodeLoadFromMemory(
  *
  * @param scopes List of memory scopes (Agent, Feature, etc.). By default only Agent scope would be chosen
  * @param subjects List of subjects (user, project, organization, etc.) to look for.
+ * @param maxFacts Maximum number of facts to inject into the prompt. Defaults to [Int.MAX_VALUE] (no limit).
+ *                 Use this to prevent context window overflow when memory grows large across many sessions.
  */
 @OptIn(InternalAgentsApi::class)
 @AIAgentBuilderDslMarker
 public inline fun <reified T> nodeLoadAllFactsFromMemory(
     name: String? = null,
     subjects: List<MemorySubject> = MemorySubject.registeredSubjects,
-    scopes: List<MemoryScopeType> = MemoryScopeType.entries
+    scopes: List<MemoryScopeType> = MemoryScopeType.entries,
+    maxFacts: Int = Int.MAX_VALUE,
 ): AIAgentNodeDelegate<T, T> = node(name) { input ->
     withMemory {
-        loadAllFactsToAgent(llm, scopes, subjects)
+        loadAllFactsToAgent(llm, scopes, subjects, maxFacts)
     }
 
     input

--- a/agents/agents-features/agents-features-memory/src/jvmTest/kotlin/ai/koog/agents/memory/AIAgentMemoryTest.kt
+++ b/agents/agents-features/agents-features-memory/src/jvmTest/kotlin/ai/koog/agents/memory/AIAgentMemoryTest.kt
@@ -31,7 +31,9 @@ import ai.koog.serialization.kotlinx.KotlinxSerializer
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.slot
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.Serializable
@@ -575,5 +577,68 @@ class AIAgentMemoryTest {
         coVerify {
             memoryProvider.load(concept, any(), any())
         }
+    }
+
+    @Test
+    fun testLoadFactsToAgentRespectsMaxFactsLimit() = runTest {
+        val memoryProvider = mockk<AgentMemoryProvider>()
+
+        // Simulate 20 sessions, each saving a distinct MultipleFacts (different concepts),
+        // reproducing the scenario where facts flood the prompt after many sessions.
+        val totalFacts = 20
+        val manyFacts = (1..totalFacts).map { i ->
+            MultipleFacts(
+                concept = Concept("session-concept-$i", "concept from session $i", FactType.MULTIPLE),
+                values = listOf("value-$i-a", "value-$i-b", "value-$i-c"),
+                timestamp = i.toLong()
+            )
+        }
+
+        // Memory returns all accumulated facts regardless of the query concept
+        coEvery {
+            memoryProvider.load(any(), any(), any())
+        } returns manyFacts
+
+        // Count how many times the LLM prompt is updated (one update per distinct concept after grouping)
+        var writeSessionCallCount = 0
+        val llm = mockk<AIAgentLLMContext> {
+            coEvery {
+                writeSession<Any?>(any())
+            } coAnswers {
+                writeSessionCallCount++
+                val block = firstArg<suspend AIAgentLLMWriteSession.() -> Any?>()
+                val writeSession = mockk<AIAgentLLMWriteSession> {
+                    every { appendPrompt(any()) } just runs
+                }
+                block.invoke(writeSession)
+            }
+        }
+
+        val memory = AgentMemory(
+            agentMemory = memoryProvider,
+            scopesProfile = MemoryScopesProfile(MemoryScopeType.AGENT to "test-agent")
+        )
+        val queryConcept = Concept("query", "query concept", FactType.MULTIPLE)
+
+        // Without a limit, all 20 facts (each with a distinct concept) should produce 20 prompt updates
+        memory.loadFactsToAgent(
+            llm = llm,
+            concept = queryConcept,
+            scopes = listOf(MemoryScopeType.AGENT),
+            subjects = listOf(MemorySubjects.User)
+        )
+        assertEquals(totalFacts, writeSessionCallCount, "Without maxFacts limit, all facts should be loaded")
+
+        // With maxFacts = 5, only 5 facts should be injected into the prompt
+        writeSessionCallCount = 0
+        val maxFacts = 5
+        memory.loadFactsToAgent(
+            llm = llm,
+            concept = queryConcept,
+            scopes = listOf(MemoryScopeType.AGENT),
+            subjects = listOf(MemorySubjects.User),
+            maxFacts = maxFacts
+        )
+        assertEquals(maxFacts, writeSessionCallCount, "With maxFacts=$maxFacts, only $maxFacts facts should be loaded")
     }
 }


### PR DESCRIPTION
## Summary

- Adds `maxFacts: Int = Int.MAX_VALUE` parameter to `loadFactsToAgent`, `loadAllFactsToAgent`, and `loadFactsToAgentImpl` in `AgentMemory`
- Threads `maxFacts` through all `nodeLoadFromMemory` and `nodeLoadAllFactsFromMemory` DSL node overloads
- Limit is applied after priority-based deduplication but before prompt injection, so the most relevant facts are kept
- Backward compatible: default of `Int.MAX_VALUE` preserves existing behavior

## Test plan

- [ ] `testLoadFactsToAgentRespectsMaxFactsLimit` — new regression test in `AIAgentMemoryTest.kt` verifies that without a limit all 20 facts load, and with `maxFacts=5` only 5 facts are injected
- [ ] Existing `MemoryNodesTest` tests pass unchanged (default behavior unaffected)
- [ ] Run `./gradlew :agents:agents-features:agents-features-memory:jvmTest`

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)