### PR TITLE
fix(tools): honor @Tool(customName) in ToolSet.asTools()

### DIFF
--- a/.air/docker.json
+++ b/.air/docker.json
@@ -1,0 +1,12 @@
+{
+    "environment": [
+        {
+            "type": "env",
+            "key": "EXAMPLE_KEY",
+            "value": "example_value"
+        }
+    ],
+    "setup": [
+        "echo \\\"Setup ran successfully with $EXAMPLE_KEY!\\\" > /tmp/setup-test.txt"
+    ]
+}

--- a/agents/agents-tools/src/jvmCommonMain/kotlin/ai/koog/agents/core/tools/reflect/ToolFromCallableExtensions.kt
+++ b/agents/agents-tools/src/jvmCommonMain/kotlin/ai/koog/agents/core/tools/reflect/ToolFromCallableExtensions.kt
@@ -66,7 +66,8 @@ public fun <T : Any> KClass<out T>.asTools(
     return this.functions.filter { m ->
         m.getPreferredToolAnnotation() != null
     }.map {
-        it.asTool(thisRef = thisRef)
+        val customName = it.getPreferredToolAnnotation()?.customName?.ifEmpty { null }
+        it.asTool(thisRef = thisRef, name = customName)
     }.apply {
         require(isNotEmpty()) { "No tools found in ${this@asTools}" }
     }

--- a/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/core/tools/reflect/ToolSetAsToolsTest.kt
+++ b/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/core/tools/reflect/ToolSetAsToolsTest.kt
@@ -1,5 +1,6 @@
 package ai.koog.agents.core.tools.reflect
 
+import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.agents.core.tools.annotations.Tool
@@ -83,6 +84,23 @@ class StringToolsImpl : ToolSet {
 
     // Not marked as a tool, should not be included
     fun uppercase(input: String): String = input.uppercase()
+}
+
+// Two tool sets that declare a method with the same raw name but distinct @Tool(customName = ...)
+class CustomNameToolsA : ToolSet {
+    @Tool(customName = "tool_a_search")
+    @LLMDescription("Searches source A")
+    fun execute(
+        @LLMDescription("Query") query: String
+    ): String = "result A: $query"
+}
+
+class CustomNameToolsB : ToolSet {
+    @Tool(customName = "tool_b_search")
+    @LLMDescription("Searches source B")
+    fun execute(
+        @LLMDescription("Query") query: String
+    ): String = "result B: $query"
 }
 
 @Serializable
@@ -204,6 +222,31 @@ class ToolSetAsToolsTest {
 
         val concatResult = concatTool.execute(concatTool.decodeArgs(concatArgs, serializer))
         assertEquals("\"Hello, World!\"", concatTool.encodeResultToStringUnsafe(concatResult, serializer), "Concat tool should return \"Hello, World!\"")
+    }
+
+    @Test
+    @OptIn(InternalAgentToolsApi::class)
+    fun testCustomNameIsUsedAsToolName() = runTest {
+        val tools = CustomNameToolsA().asTools()
+
+        assertEquals(1, tools.size, "Should have a single tool")
+        assertEquals(
+            "tool_a_search",
+            tools.single().descriptor.name,
+            "Tool name should come from @Tool(customName = ...), not the raw function name"
+        )
+    }
+
+    @Test
+    @OptIn(InternalAgentToolsApi::class)
+    fun testCustomNameAvoidsCollisionForSameMethodName() = runTest {
+        val registry = ToolRegistry {
+            tools(CustomNameToolsA())
+            tools(CustomNameToolsB())
+        }
+
+        assertNotNull(registry.getTool("tool_a_search"), "tool_a_search should be registered")
+        assertNotNull(registry.getTool("tool_b_search"), "tool_b_search should be registered")
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #12.

`KClass.asTools()` filtered methods by their `@Tool` annotation but never read `customName`, so tools registered via `ToolSet.asTools()` / `ToolRegistryBuilder.tools(ToolSet)` were always named after the raw Kotlin function. Two tool sets declaring a method with the same name (e.g. `execute`) then collided with `IllegalArgumentException: Tool "execute" is already defined`, even when each carried a distinct `@Tool(customName = ...)`.

## Change

In `ToolFromCallableExtensions.kt`, `KClass<T>.asTools()` now reads `customName` (when non-empty) from the preferred `@Tool` annotation and forwards it as the tool name to `asTool()`. The inline `asToolsByClass<T>()` delegates to `asTools()`, so it picks up the fix automatically.

```kotlin
.map {
    val customName = it.getPreferredToolAnnotation()?.customName?.ifEmpty { null }
    it.asTool(thisRef = thisRef, name = customName)
}
```

## Tests

Added to `ToolSetAsToolsTest`:
- `testCustomNameIsUsedAsToolName` — descriptor name comes from `customName`, not the raw function name.
- `testCustomNameAvoidsCollisionForSameMethodName` — two tool sets each with `execute` but distinct `customName` register without collision.

`./gradlew :agents:agents-tools:jvmTest --tests "ai.koog.agents.core.tools.reflect.ToolSetAsToolsTest"` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)