### PR TITLE
feat(agents): add streaming mode to singleRunStrategy

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentSimpleStrategies.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentSimpleStrategies.kt
@@ -2,6 +2,7 @@ package ai.koog.agents.core.agent
 
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.dsl.builder.forwardTo
+import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.nodeExecuteMultipleTools
 import ai.koog.agents.core.dsl.extension.nodeExecuteTool
@@ -13,6 +14,11 @@ import ai.koog.agents.core.dsl.extension.onAssistantMessage
 import ai.koog.agents.core.dsl.extension.onMultipleAssistantMessages
 import ai.koog.agents.core.dsl.extension.onMultipleToolCalls
 import ai.koog.agents.core.dsl.extension.onToolCall
+import ai.koog.agents.core.environment.ReceivedToolResult
+import ai.koog.agents.core.environment.result
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.streaming.toMessageResponses
+import kotlinx.coroutines.flow.toList
 import kotlin.jvm.JvmOverloads
 
 /**
@@ -29,14 +35,24 @@ import kotlin.jvm.JvmOverloads
  *                - [ToolCalls.SEQUENTIAL]: Executes multiple tool calls sequentially.
  *                - [ToolCalls.PARALLEL]: Executes multiple tool calls in parallel.
  *                - [ToolCalls.SINGLE_RUN_SEQUENTIAL]: Executes a single tool call per step.
+ * @param stream When `true`, the LLM is queried via a streaming request (`requestLLMStreaming`) instead of a regular
+ *               one. This makes the agent emit streaming pipeline events (for example,
+ *               `onLLMStreamingFrameReceived`) so installed event handlers can react to text deltas in real time.
+ *               The streamed frames are collected into [Message.Response]s, so tool calling keeps working exactly as
+ *               in the non-streaming flow. Defaults to `false`.
+ *               Note: streaming always uses the multiple-tool-call flow, so [ToolCalls.SINGLE_RUN_SEQUENTIAL] behaves
+ *               like [ToolCalls.SEQUENTIAL] when `stream` is `true`.
  * @return An instance of AIAgentStrategy configured according to the specified run mode.
  */
 @JvmOverloads
-public fun singleRunStrategy(runMode: ToolCalls = ToolCalls.SEQUENTIAL): AIAgentGraphStrategy<String, String> =
+public fun singleRunStrategy(
+    runMode: ToolCalls = ToolCalls.SEQUENTIAL,
+    stream: Boolean = false,
+): AIAgentGraphStrategy<String, String> =
     when (runMode) {
-        ToolCalls.SEQUENTIAL -> singleRunWithParallelAbility(false)
-        ToolCalls.PARALLEL -> singleRunWithParallelAbility(true)
-        ToolCalls.SINGLE_RUN_SEQUENTIAL -> singleRunModeStrategy()
+        ToolCalls.SEQUENTIAL -> if (stream) singleRunStreaming(parallelTools = false) else singleRunWithParallelAbility(false)
+        ToolCalls.PARALLEL -> if (stream) singleRunStreaming(parallelTools = true) else singleRunWithParallelAbility(true)
+        ToolCalls.SINGLE_RUN_SEQUENTIAL -> if (stream) singleRunStreaming(parallelTools = false) else singleRunModeStrategy()
     }
 
 private fun singleRunWithParallelAbility(parallelTools: Boolean) = strategy("single_run_sequential") {
@@ -74,6 +90,62 @@ private fun singleRunModeStrategy() = strategy("single_run") {
     edge(nodeExecuteTool forwardTo nodeSendToolResult)
     edge(nodeSendToolResult forwardTo nodeFinish onAssistantMessage { true })
     edge(nodeSendToolResult forwardTo nodeExecuteTool onToolCall { true })
+}
+
+/**
+ * Streaming counterpart of [singleRunWithParallelAbility].
+ *
+ * It has the same graph shape, but queries the LLM through [requestLLMStreaming][ai.koog.agents.core.agent.session.AIAgentLLMWriteSession.requestLLMStreaming]
+ * so that streaming pipeline events are emitted while the response is produced. The streamed frames are collected and
+ * converted back into [Message.Response]s via [toMessageResponses], which keeps the downstream tool-call/finish
+ * branching identical to the non-streaming flow.
+ */
+private fun singleRunStreaming(parallelTools: Boolean) = strategy("single_run_streaming") {
+    val nodeCallLLM by node<String, List<Message.Response>>("nodeCallLLMStreaming") { message ->
+        llm.writeSession {
+            appendPrompt {
+                user(message)
+            }
+
+            requestLLMStreaming()
+                .toList()
+                .toMessageResponses()
+                .also { appendPrompt { messages(it) } }
+        }
+    }
+    val nodeExecuteTool by nodeExecuteMultipleTools(parallelTools = parallelTools)
+    val nodeSendToolResult by node<List<ReceivedToolResult>, List<Message.Response>>("nodeSendToolResultStreaming") { results ->
+        llm.writeSession {
+            appendPrompt {
+                tool {
+                    results.forEach { result(it) }
+                }
+            }
+
+            requestLLMStreaming()
+                .toList()
+                .toMessageResponses()
+                .also { appendPrompt { messages(it) } }
+        }
+    }
+
+    edge(nodeStart forwardTo nodeCallLLM)
+    edge(nodeCallLLM forwardTo nodeExecuteTool onMultipleToolCalls { true })
+    edge(
+        nodeCallLLM forwardTo nodeFinish
+            onMultipleAssistantMessages { true }
+            transformed { it.joinToString("\n") { message -> message.content } }
+    )
+
+    edge(nodeExecuteTool forwardTo nodeSendToolResult)
+
+    edge(nodeSendToolResult forwardTo nodeExecuteTool onMultipleToolCalls { true })
+
+    edge(
+        nodeSendToolResult forwardTo nodeFinish
+            onMultipleAssistantMessages { true }
+            transformed { it.joinToString("\n") { message -> message.content } }
+    )
 }
 
 /**

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/SingleRunStrategyTests.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/SingleRunStrategyTests.kt
@@ -253,6 +253,75 @@ class SingleRunStrategyTests {
     }
 
     @Test
+    fun test_SingleRunStrategy_Streaming_AssistantMessages() = runTest {
+        val actualToolCalls = mutableListOf<String>()
+
+        val testToolRegistry = ToolRegistry {
+            tool(CreateTool)
+        }
+
+        val mockLLMApi = getMockExecutor(serializer) {
+            mockLLMAnswer("Task solved!") onRequestContains "Solve task"
+            mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            mockLLMApi,
+            OllamaModels.Meta.LLAMA_3_2,
+            strategy = singleRunStrategy(stream = true),
+            toolRegistry = testToolRegistry
+        ) {
+            install(EventHandler) {
+                onToolCallStarting { eventContext -> actualToolCalls += eventContext.toolArgs.toString() }
+            }
+        }
+
+        val result = agent.run("Solve task", null)
+
+        assertEquals(0, actualToolCalls.size)
+        assertEquals("Task solved!", result)
+    }
+
+    @Test
+    fun test_SingleRunStrategy_Streaming_WithToolCalls() = runTest {
+        val actualToolCalls = mutableListOf<String>()
+
+        val testToolRegistry = ToolRegistry {
+            tool(CreateTool)
+        }
+
+        val mockLLMApi = getMockExecutor(serializer) {
+            mockLLMAnswer("Hello!") onRequestContains "Hello"
+            mockLLMAnswer("Tools called!") onRequestContains "created"
+            mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
+
+            // Mock LLM tool calls
+            val toolCalls = listOf(
+                CreateTool to CreateTool.Args("solve"),
+                CreateTool to CreateTool.Args("solve2"),
+                CreateTool to CreateTool.Args("solve3"),
+            )
+            mockLLMToolCall(toolCalls) onRequestEquals "Solve task"
+        }
+
+        val agent = AIAgent(
+            mockLLMApi,
+            OllamaModels.Meta.LLAMA_3_2,
+            strategy = singleRunStrategy(stream = true),
+            toolRegistry = testToolRegistry
+        ) {
+            install(EventHandler) {
+                onToolCallStarting { eventContext -> actualToolCalls += eventContext.toolArgs.toString() }
+            }
+        }
+
+        val result = agent.run("Solve task", null)
+
+        assertEquals(3, actualToolCalls.size)
+        assertEquals("Tools called!", result)
+    }
+
+    @Test
     fun test_SingleRunStrategy_Parallel_MixedResults() = runTest {
         val actualToolCalls = mutableListOf<String>()
 

--- a/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/StreamingEventHandlerTest.kt
+++ b/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/StreamingEventHandlerTest.kt
@@ -2,6 +2,7 @@ package ai.koog.agents.features.eventHandler.feature
 
 import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
+import ai.koog.agents.core.agent.singleRunStrategy
 import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestStreaming
@@ -47,6 +48,47 @@ class StreamingEventHandlerTest {
         // Verify the stream frame contains the expected response
         val frameWithContent = streamFrameEvents.firstOrNull { it.contains(assistantResponse) }
         assertTrue(frameWithContent != null, "Stream frame should contain the assistant response")
+    }
+
+    @Test
+    fun `test singleRunStrategy with streaming enabled triggers streaming frame events`() = runTest {
+        // Reproduces the reported issue: a plain agent built with the default-style strategy never emitted
+        // streaming events because singleRunStrategy used a non-streaming LLM request. With stream = true the
+        // strategy must query the LLM via requestLLMStreaming and emit onLLMStreamingFrameReceived events.
+        val userMessage = "Test streaming"
+        val assistantResponse = "Streaming response"
+        val eventsCollector = mockStreaming(
+            strategy = singleRunStrategy(stream = true),
+            buildLlmMock = { mockLLMAnswer(assistantResponse) onRequestContains userMessage }
+        ) { agent ->
+            agent.run(userMessage, null)
+        }
+
+        assertEventsCollected(eventsCollector)
+
+        val streamFrameEvents = eventsCollector.collectedEvents.filter { it.contains("OnLLMStreamingFrameReceived") }
+        assertTrue(streamFrameEvents.isNotEmpty(), "singleRunStrategy(stream = true) should emit OnLLMStreamingFrameReceived events")
+
+        val frameWithContent = streamFrameEvents.firstOrNull { it.contains(assistantResponse) }
+        assertTrue(frameWithContent != null, "Stream frame should contain the assistant response")
+    }
+
+    @Test
+    fun `test singleRunStrategy without streaming does not trigger streaming frame events`() = runTest {
+        // Counterpart of the test above: the default (non-streaming) strategy must not emit streaming events.
+        val userMessage = "Test streaming"
+        val assistantResponse = "Streaming response"
+        val eventsCollector = mockStreaming(
+            strategy = singleRunStrategy(),
+            buildLlmMock = { mockLLMAnswer(assistantResponse) onRequestContains userMessage }
+        ) { agent ->
+            agent.run(userMessage, null)
+        }
+
+        assertEventsCollected(eventsCollector)
+
+        val streamFrameEvents = eventsCollector.collectedEvents.filter { it.contains("OnLLMStreamingFrameReceived") }
+        assertTrue(streamFrameEvents.isEmpty(), "singleRunStrategy() without streaming should not emit OnLLMStreamingFrameReceived events")
     }
 
     @Test

--- a/docs/docs/streaming-api.md
+++ b/docs/docs/streaming-api.md
@@ -249,6 +249,30 @@ derive text chunks via `filterTextOnly()` or collect them with `collectText()`.
 
 You can listen to stream events in [agent event handlers](agent-event-handlers.md).
 
+!!! note
+
+    Streaming events such as `onLLMStreamingFrameReceived` are emitted only while the agent makes a **streaming**
+    LLM request (for example, via a `nodeLLMRequestStreaming` node). The default strategy used by a basic agent
+    (`singleRunStrategy()`) performs regular, non-streaming requests, so these handlers are never invoked for it.
+
+    To get streaming events from a basic agent, enable streaming on the built-in strategy:
+
+    ```kotlin
+    val agent = AIAgent(
+        promptExecutor = executor,
+        llmModel = model,
+        strategy = singleRunStrategy(stream = true),
+    ) {
+        handleEvents {
+            onLLMStreamingFrameReceived { context ->
+                (context.streamFrame as? StreamFrame.TextDelta)?.let { print(it.text) }
+            }
+        }
+    }
+    ```
+
+    Or use a custom strategy with a `nodeLLMRequestStreaming` node, as shown below.
+
 === "Kotlin"
 
     <!--- INCLUDE


### PR DESCRIPTION
## Summary

Fixes #14.

The streaming-event pipeline (`onLLMStreamingFrameReceived`, etc.) is wired up correctly and fires whenever the agent makes a **streaming** LLM call. The reported problem is that the default strategy used by basic agents — `singleRunStrategy()`, the default for the simple `AIAgent(promptExecutor, llmModel)` constructor — queries the LLM with a **non-streaming** request (`nodeLLMRequestMultiple` / `nodeLLMRequest`). So no stream frames are ever produced and the documented "listen to stream events" handler is never invoked.

## Change

Add a `stream: Boolean = false` parameter to `singleRunStrategy(...)`:

```kotlin
val agent = AIAgent(
    promptExecutor = executor,
    llmModel = model,
    strategy = singleRunStrategy(stream = true),
) {
    handleEvents {
        onLLMStreamingFrameReceived { ctx ->
            (ctx.streamFrame as? StreamFrame.TextDelta)?.let { print(it.text) }
        }
    }
}
```

When `stream = true`, the strategy queries the LLM via `requestLLMStreaming`, then collects the frames back into `Message.Response`s with `toMessageResponses()` — so the downstream tool-call/finish branching is identical to the non-streaming flow and **tool calling keeps working**.

### Design notes
- Streaming is kept **orthogonal** to the `ToolCalls` execution mode rather than folded into the enum, so it composes with sequential/parallel tool execution (a `ToolCalls.STREAMING` value couldn't express "streaming + parallel tools"). `@JvmOverloads` keeps the Java API and full backward compatibility.
- No plumbing changes — `ContextualPromptExecutor` already emits the streaming events correctly.
- `SINGLE_RUN_SEQUENTIAL` + `stream = true` uses the multiple-tool-call flow (documented in KDoc), since streamed frames are naturally collected into a list.

## Tests
- `SingleRunStrategyTests`: streaming with assistant-only response and with tool calls (functional parity).
- `StreamingEventHandlerTest`: `singleRunStrategy(stream = true)` emits `OnLLMStreamingFrameReceived`; `singleRunStrategy()` does not.

## Docs
- `streaming-api.md`: note that streaming event handlers require a streaming strategy, with the `singleRunStrategy(stream = true)` snippet for the basic-agent case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)